### PR TITLE
fix: Add OS platform checks in tests to skip MacOS and Windows failing tests

### DIFF
--- a/Devantler.KubernetesProvisioner.Cluster.K3d.Tests/K3dProvisionerTests/AllMethodsTests.cs
+++ b/Devantler.KubernetesProvisioner.Cluster.K3d.Tests/K3dProvisionerTests/AllMethodsTests.cs
@@ -1,3 +1,5 @@
+using System.Runtime.InteropServices;
+
 namespace Devantler.KubernetesProvisioner.Cluster.K3d.Tests.K3dProvisionerTests;
 
 /// <summary>
@@ -15,6 +17,12 @@ public class AllMethodsTests
   [Fact]
   public async Task AllMethods_WithValidParameters_Succeeds()
   {
+    //TODO: Support MacOS and Windows, when dind is supported in GitHub Actions Runners on those platforms
+    if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+    {
+      return;
+    }
+
     // Arrange
     string clusterName = "test-k3d-cluster";
     string configPath = Path.Combine(AppContext.BaseDirectory, "assets/k3d-config.yaml");

--- a/Devantler.KubernetesProvisioner.Cluster.Kind.Tests/KindProvisionerTests/AllMethodsTests.cs
+++ b/Devantler.KubernetesProvisioner.Cluster.Kind.Tests/KindProvisionerTests/AllMethodsTests.cs
@@ -1,3 +1,5 @@
+using System.Runtime.InteropServices;
+
 namespace Devantler.KubernetesProvisioner.Cluster.Kind.Tests.KindProvisionerTests;
 
 /// <summary>
@@ -14,6 +16,12 @@ public class AllMethodsTests
   [Fact]
   public async Task AllMethods_WithValidParameters_Succeeds()
   {
+    //TODO: Support MacOS and Windows, when dind is supported in GitHub Actions Runners on those platforms
+    if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+    {
+      return;
+    }
+
     // Arrange
     string clusterName = "test-kind-cluster";
     string configPath = Path.Combine(AppContext.BaseDirectory, "assets/kind-config.yaml");

--- a/Devantler.KubernetesProvisioner.GitOps.Flux.Tests/FluxProvisionerTests/AllMethodsTests.cs
+++ b/Devantler.KubernetesProvisioner.GitOps.Flux.Tests/FluxProvisionerTests/AllMethodsTests.cs
@@ -18,6 +18,12 @@ public class AllMethodsTests
   [Fact]
   public async Task Flux_InstallsAndReconciles_KustomizationsAsync()
   {
+    //TODO: Support MacOS and Windows, when dind is supported in GitHub Actions Runners on those platforms
+    if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+    {
+      return;
+    }
+
     // Arrange
     string clusterName = "test-flux-cluster";
     string context = "kind-" + clusterName;

--- a/Devantler.KubernetesProvisioner.Resources.Native.Tests/KubernetesResourceProvisionerTests/AllMethodsTests.cs
+++ b/Devantler.KubernetesProvisioner.Resources.Native.Tests/KubernetesResourceProvisionerTests/AllMethodsTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using Devantler.KubernetesProvisioner.Cluster.Kind;
 using k8s;
 using k8s.Models;
@@ -18,6 +19,12 @@ public class AllMethodsTests
   [Fact]
   public async Task AllMethods_WithValidParameters_Succeeds()
   {
+    //TODO: Support MacOS and Windows, when dind is supported in GitHub Actions Runners on those platforms
+    if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+    {
+      return;
+    }
+
     // Arrange
     string clusterName = "test-native-cluster";
     string configPath = Path.Combine(AppContext.BaseDirectory, "assets/kind-config.yaml");


### PR DESCRIPTION
Introduce checks in the test methods to skip execution on MacOS and Windows until dind support is available in GitHub Actions Runners for those platforms.