### PR TITLE
fix: Add network option to cluster creation in KindProvisioner

### DIFF
--- a/Devantler.KubernetesProvisioner.Cluster.Kind/KindProvisioner.cs
+++ b/Devantler.KubernetesProvisioner.Cluster.Kind/KindProvisioner.cs
@@ -58,6 +58,7 @@ public class KindProvisioner : IKubernetesClusterProvisioner
       "create",
       "cluster",
       "--name", clusterName,
+      "--network", clusterName,
       "--config", configPath
     };
     var (exitCode, _) = await KindCLI.Kind.RunAsync([.. args], cancellationToken: cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
Introduce a network option for cluster creation to enhance configuration flexibility in the KindProvisioner.