### PR TITLE
refactor: Refactor OS platform checks for GitHub Actions compatibility

### DIFF
--- a/Devantler.KubernetesProvisioner.Cluster.Kind.Tests/KindProvisionerTests/AllMethodsTests.cs
+++ b/Devantler.KubernetesProvisioner.Cluster.Kind.Tests/KindProvisionerTests/AllMethodsTests.cs
@@ -17,7 +17,7 @@ public class AllMethodsTests
   public async Task AllMethods_WithValidParameters_Succeeds()
   {
     //TODO: Support MacOS and Windows, when dind is supported in GitHub Actions Runners on those platforms
-    if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+    if ((RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) && Environment.GetEnvironmentVariable("GITHUB_ACTIONS") == "true")
     {
       return;
     }

--- a/Devantler.KubernetesProvisioner.GitOps.Flux.Tests/FluxProvisionerTests/AllMethodsTests.cs
+++ b/Devantler.KubernetesProvisioner.GitOps.Flux.Tests/FluxProvisionerTests/AllMethodsTests.cs
@@ -19,7 +19,7 @@ public class AllMethodsTests
   public async Task Flux_InstallsAndReconciles_KustomizationsAsync()
   {
     //TODO: Support MacOS and Windows, when dind is supported in GitHub Actions Runners on those platforms
-    if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+    if ((RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) && Environment.GetEnvironmentVariable("GITHUB_ACTIONS") == "true")
     {
       return;
     }

--- a/Devantler.KubernetesProvisioner.Resources.Native.Tests/KubernetesResourceProvisionerTests/AllMethodsTests.cs
+++ b/Devantler.KubernetesProvisioner.Resources.Native.Tests/KubernetesResourceProvisionerTests/AllMethodsTests.cs
@@ -20,7 +20,7 @@ public class AllMethodsTests
   public async Task AllMethods_WithValidParameters_Succeeds()
   {
     //TODO: Support MacOS and Windows, when dind is supported in GitHub Actions Runners on those platforms
-    if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+    if ((RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) && Environment.GetEnvironmentVariable("GITHUB_ACTIONS") == "true")
     {
       return;
     }


### PR DESCRIPTION
Update platform checks to skip support for MacOS and Windows only in GitHub Actions, allowing for better compatibility in CI environments.