### PR TITLE
chore: run K3d and Kind commands silently

### DIFF
--- a/src/Devantler.KubernetesProvisioner.Cluster.K3d/K3dProvisioner.cs
+++ b/src/Devantler.KubernetesProvisioner.Cluster.K3d/K3dProvisioner.cs
@@ -41,7 +41,7 @@ public class K3dProvisioner : IKubernetesClusterProvisioner
   public async Task<IEnumerable<string>> ListAsync(CancellationToken cancellationToken = default)
   {
     var args = new List<string> { "cluster", "list" };
-    var (exitCode, output) = await K3dCLI.K3d.RunAsync([.. args], cancellationToken: cancellationToken).ConfigureAwait(false);
+    var (exitCode, output) = await K3dCLI.K3d.RunAsync([.. args], silent: true, cancellationToken: cancellationToken).ConfigureAwait(false);
     if (exitCode != 0)
     {
       throw new KubernetesClusterProvisionerException("Failed to list K3d clusters.");

--- a/src/Devantler.KubernetesProvisioner.Cluster.Kind/KindProvisioner.cs
+++ b/src/Devantler.KubernetesProvisioner.Cluster.Kind/KindProvisioner.cs
@@ -40,7 +40,7 @@ public class KindProvisioner : IKubernetesClusterProvisioner
   public async Task<IEnumerable<string>> ListAsync(CancellationToken cancellationToken = default)
   {
     var args = new List<string> { "get", "clusters" };
-    var (exitCode, result) = await KindCLI.Kind.RunAsync([.. args], cancellationToken: cancellationToken).ConfigureAwait(false);
+    var (exitCode, result) = await KindCLI.Kind.RunAsync([.. args], silent: true, cancellationToken: cancellationToken).ConfigureAwait(false);
     if (exitCode != 0)
     {
       throw new KubernetesClusterProvisionerException("Failed to list Kind clusters.");


### PR DESCRIPTION
Update K3d and Kind provisioners to execute commands without output, enhancing the user experience by reducing unnecessary console clutter.