### PR TITLE
fix: update dependencies and enable silent command execution

### DIFF
--- a/src/Devantler.KubernetesProvisioner.Cluster.K3d/Devantler.KubernetesProvisioner.Cluster.K3d.csproj
+++ b/src/Devantler.KubernetesProvisioner.Cluster.K3d/Devantler.KubernetesProvisioner.Cluster.K3d.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devantler.K3dCLI" Version="1.2.5" />
+    <PackageReference Include="Devantler.K3dCLI" Version="1.2.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Devantler.KubernetesProvisioner.Cluster.K3d/K3dProvisioner.cs
+++ b/src/Devantler.KubernetesProvisioner.Cluster.K3d/K3dProvisioner.cs
@@ -33,7 +33,7 @@ public class K3dProvisioner : IKubernetesClusterProvisioner
       "get",
       clusterName
     };
-    var (exitCode, _) = await K3dCLI.K3d.RunAsync([.. args], CliWrap.CommandResultValidation.None, cancellationToken: cancellationToken).ConfigureAwait(false);
+    var (exitCode, _) = await K3dCLI.K3d.RunAsync([.. args], CliWrap.CommandResultValidation.None, silent: true, cancellationToken: cancellationToken).ConfigureAwait(false);
     return exitCode == 0;
   }
 

--- a/src/Devantler.KubernetesProvisioner.Cluster.Kind/Devantler.KubernetesProvisioner.Cluster.Kind.csproj
+++ b/src/Devantler.KubernetesProvisioner.Cluster.Kind/Devantler.KubernetesProvisioner.Cluster.Kind.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devantler.KindCLI" Version="1.2.5" />
+    <PackageReference Include="Devantler.KindCLI" Version="1.2.6" />
     <PackageReference Include="Docker.DotNet" Version="3.125.15" />
     <PackageReference Include="KubernetesClient" Version="16.0.2" />
   </ItemGroup>

--- a/src/Devantler.KubernetesProvisioner.Cluster.Kind/KindProvisioner.cs
+++ b/src/Devantler.KubernetesProvisioner.Cluster.Kind/KindProvisioner.cs
@@ -1,4 +1,5 @@
-﻿using Devantler.KubernetesProvisioner.Cluster.Core;
+﻿using CliWrap;
+using Devantler.KubernetesProvisioner.Cluster.Core;
 using Docker.DotNet;
 using Docker.DotNet.Models;
 using k8s;
@@ -32,8 +33,9 @@ public class KindProvisioner : IKubernetesClusterProvisioner
   /// <inheritdoc />
   public async Task<bool> ExistsAsync(string clusterName, CancellationToken cancellationToken = default)
   {
-    var clusterNames = await ListAsync(cancellationToken).ConfigureAwait(false);
-    return clusterNames.Contains(clusterName);
+    var args = new List<string> { "get", "clusters" };
+    var (exitCode, result) = await KindCLI.Kind.RunAsync([.. args], CommandResultValidation.None, silent: true, cancellationToken: cancellationToken).ConfigureAwait(false);
+    return exitCode == 0 && result.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).Contains(clusterName);
   }
 
   /// <inheritdoc />

--- a/src/Devantler.KubernetesProvisioner.GitOps.Flux/Devantler.KubernetesProvisioner.GitOps.Flux.csproj
+++ b/src/Devantler.KubernetesProvisioner.GitOps.Flux/Devantler.KubernetesProvisioner.GitOps.Flux.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Devantler.FluxCLI" Version="1.5.1" />
-    <PackageReference Include="Devantler.KubernetesGenerator.Flux" Version="1.5.12" />
+    <PackageReference Include="Devantler.KubernetesGenerator.Flux" Version="1.5.15" />
     <PackageReference Include="Devantler.Commons.Utils" Version="0.4.3" />
     <PackageReference Include="MedallionTopologicalSort" Version="1.0.0" />
   </ItemGroup>


### PR DESCRIPTION
Update the Devantler.K3dCLI and Devantler.KindCLI packages to version 1.2.6. Enable silent mode for command execution in the K3d and Kind CLI operations to reduce output noise. Update the Devantler.KubernetesGenerator.Flux package to version 1.5.15.