### PR TITLE
feat: add kubeconfig property to IGitOpsProvisioner

### DIFF
--- a/src/Devantler.KubernetesProvisioner.GitOps.Core/IGitOpsProvisioner.cs
+++ b/src/Devantler.KubernetesProvisioner.GitOps.Core/IGitOpsProvisioner.cs
@@ -6,6 +6,11 @@
 public interface IGitOpsProvisioner
 {
   /// <summary>
+  /// The Kubernetes kubeconfig.
+  /// </summary>
+  string? Kubeconfig { get; set; }
+
+  /// <summary>
   /// The Kubernetes context.
   /// </summary>
   string? Context { get; set; }

--- a/src/Devantler.KubernetesProvisioner.Resources.Native/KubernetesResourceProvisioner.cs
+++ b/src/Devantler.KubernetesProvisioner.Resources.Native/KubernetesResourceProvisioner.cs
@@ -8,12 +8,13 @@ namespace Devantler.KubernetesProvisioner.Resources.Native;
 /// <remarks>
 /// Initializes a new instance of the <see cref="KubernetesResourceProvisioner"/> class.
 /// </remarks>
+/// <param name="kubeconfig"></param>
 /// <param name="context"></param>
-public sealed class KubernetesResourceProvisioner(string? context = default) : Kubernetes(BuildConfig(context))
+public sealed class KubernetesResourceProvisioner(string? kubeconfig = default, string? context = default) : Kubernetes(BuildConfig(kubeconfig, context))
 {
-  static KubernetesClientConfiguration BuildConfig(string? context)
+  static KubernetesClientConfiguration BuildConfig(string? kubeconfig, string? context)
   {
-    var kubeConfig = KubernetesClientConfiguration.LoadKubeConfig();
+    var kubeConfig = KubernetesClientConfiguration.LoadKubeConfig(kubeconfig);
     var config = KubernetesClientConfiguration.BuildConfigFromConfigObject(kubeConfig, context);
     return config;
   }


### PR DESCRIPTION
Introduce a kubeconfig property to the IGitOpsProvisioner interface, allowing for more flexible Kubernetes configuration management. Update related classes and methods to utilize the kubeconfig parameter where necessary.