### PR TITLE
feat: add kubeconfig parameter to CNIProvisioners

### DIFF
--- a/src/Devantler.KubernetesProvisioner.CNI.Cilium/CiliumProvisioner.cs
+++ b/src/Devantler.KubernetesProvisioner.CNI.Cilium/CiliumProvisioner.cs
@@ -11,6 +11,7 @@ public class CiliumProvisioner : IKubernetesCNIProvisioner
   /// <summary>
   /// Installs Cilium as a CNI.
   /// </summary>
+  /// <param name="kubeconfig"></param>
   /// <param name="context"></param>
   /// <param name="cancellationToken"></param>
   public async Task InstallAsync(string? kubeconfig, string? context = null, CancellationToken cancellationToken = default)

--- a/src/Devantler.KubernetesProvisioner.CNI.Cilium/CiliumProvisioner.cs
+++ b/src/Devantler.KubernetesProvisioner.CNI.Cilium/CiliumProvisioner.cs
@@ -6,22 +6,26 @@ namespace Devantler.KubernetesProvisioner.CNI.Cilium;
 /// <summary>
 /// A Cilium CNI provisioner.
 /// </summary>
-public class CiliumProvisioner : IKubernetesCNIProvisioner
+public class CiliumProvisioner(string? kubeconfig = default, string? context = default) : IKubernetesCNIProvisioner
 {
+  /// <inheritdoc/>
+  public string? Kubeconfig { get; set; } = kubeconfig;
+
+  /// <inheritdoc/>
+  public string? Context { get; set; } = context;
+
   /// <summary>
   /// Installs Cilium as a CNI.
   /// </summary>
-  /// <param name="kubeconfig"></param>
-  /// <param name="context"></param>
   /// <param name="cancellationToken"></param>
-  public async Task InstallAsync(string? kubeconfig, string? context = null, CancellationToken cancellationToken = default)
+  public async Task InstallAsync(CancellationToken cancellationToken = default)
   {
     var installArgs = new List<string>
     {
       "install"
     };
-    installArgs.AddIfNotNull("--kubeconfig={0}", kubeconfig);
-    installArgs.AddIfNotNull("--context={0}", context);
+    installArgs.AddIfNotNull("--kubeconfig={0}", Kubeconfig);
+    installArgs.AddIfNotNull("--context={0}", Context);
 
     await CiliumCLI.Cilium.RunAsync([.. installArgs], cancellationToken: cancellationToken).ConfigureAwait(false);
     var waitArgs = new List<string>
@@ -29,8 +33,8 @@ public class CiliumProvisioner : IKubernetesCNIProvisioner
       "status",
       "--wait"
     };
-    waitArgs.AddIfNotNull("--kubeconfig={0}", kubeconfig);
-    waitArgs.AddIfNotNull("--context={0}", context);
+    waitArgs.AddIfNotNull("--kubeconfig={0}", Kubeconfig);
+    waitArgs.AddIfNotNull("--context={0}", Context);
     await CiliumCLI.Cilium.RunAsync([.. waitArgs], cancellationToken: cancellationToken).ConfigureAwait(false);
   }
 }

--- a/src/Devantler.KubernetesProvisioner.CNI.Cilium/CiliumProvisioner.cs
+++ b/src/Devantler.KubernetesProvisioner.CNI.Cilium/CiliumProvisioner.cs
@@ -13,12 +13,13 @@ public class CiliumProvisioner : IKubernetesCNIProvisioner
   /// </summary>
   /// <param name="context"></param>
   /// <param name="cancellationToken"></param>
-  public async Task InstallAsync(string? context = null, CancellationToken cancellationToken = default)
+  public async Task InstallAsync(string? kubeconfig, string? context = null, CancellationToken cancellationToken = default)
   {
     var installArgs = new List<string>
     {
       "install"
     };
+    installArgs.AddIfNotNull("--kubeconfig={0}", kubeconfig);
     installArgs.AddIfNotNull("--context={0}", context);
 
     await CiliumCLI.Cilium.RunAsync([.. installArgs], cancellationToken: cancellationToken).ConfigureAwait(false);
@@ -27,6 +28,7 @@ public class CiliumProvisioner : IKubernetesCNIProvisioner
       "status",
       "--wait"
     };
+    waitArgs.AddIfNotNull("--kubeconfig={0}", kubeconfig);
     waitArgs.AddIfNotNull("--context={0}", context);
     await CiliumCLI.Cilium.RunAsync([.. waitArgs], cancellationToken: cancellationToken).ConfigureAwait(false);
   }

--- a/src/Devantler.KubernetesProvisioner.CNI.Core/IKubernetesCNIProvisioner.cs
+++ b/src/Devantler.KubernetesProvisioner.CNI.Core/IKubernetesCNIProvisioner.cs
@@ -8,8 +8,9 @@ public interface IKubernetesCNIProvisioner
   /// <summary>
   /// Installs a CNI.
   /// </summary>
+  /// <param name="kubeconfig"></param>
   /// <param name="context"></param>
   /// <param name="cancellationToken"></param>
   /// <returns></returns>
-  Task InstallAsync(string? context = default, CancellationToken cancellationToken = default);
+  Task InstallAsync(string? kubeconfig = default, string? context = default, CancellationToken cancellationToken = default);
 }

--- a/src/Devantler.KubernetesProvisioner.CNI.Core/IKubernetesCNIProvisioner.cs
+++ b/src/Devantler.KubernetesProvisioner.CNI.Core/IKubernetesCNIProvisioner.cs
@@ -6,11 +6,19 @@
 public interface IKubernetesCNIProvisioner
 {
   /// <summary>
+  /// The path to the kubeconfig file.
+  /// </summary>
+  public string? Kubeconfig { get; set; }
+
+  /// <summary>
+  /// The context to use.
+  /// </summary>
+  public string? Context { get; set; }
+
+  /// <summary>
   /// Installs a CNI.
   /// </summary>
-  /// <param name="kubeconfig"></param>
-  /// <param name="context"></param>
   /// <param name="cancellationToken"></param>
   /// <returns></returns>
-  Task InstallAsync(string? kubeconfig = default, string? context = default, CancellationToken cancellationToken = default);
+  Task InstallAsync(CancellationToken cancellationToken = default);
 }

--- a/tests/Devantler.KubernetesProvisioner.CNI.Cilium.Tests/CiliumProvisionerTests/AllMethodsTests.cs
+++ b/tests/Devantler.KubernetesProvisioner.CNI.Cilium.Tests/CiliumProvisionerTests/AllMethodsTests.cs
@@ -24,7 +24,7 @@ public class AllMethodsTests
     // Arrange
     string clusterName = "test-cilium-cluster";
     string context = "kind-" + clusterName;
-    CiliumProvisioner ciliumProvisioner = new(context: "kind-" + clusterName);
+    CiliumProvisioner ciliumProvisioner = new(context: context);
 
     string configPath = Path.Combine(AppContext.BaseDirectory, "assets/kind.yaml");
     var cancellationToken = new CancellationToken();

--- a/tests/Devantler.KubernetesProvisioner.CNI.Cilium.Tests/CiliumProvisionerTests/AllMethodsTests.cs
+++ b/tests/Devantler.KubernetesProvisioner.CNI.Cilium.Tests/CiliumProvisionerTests/AllMethodsTests.cs
@@ -10,7 +10,6 @@ namespace Devantler.KubernetesProvisioner.CNI.Cilium.Tests.CiliumProvisionerTest
 public class AllMethodsTests
 {
   readonly KindProvisioner _kindProvisioner = new();
-  readonly CiliumProvisioner _ciliumProvisioner = new();
   /// <summary>
   /// Test to verify that flux installs and reconciles kustomizations.
   /// </summary>
@@ -25,13 +24,15 @@ public class AllMethodsTests
     // Arrange
     string clusterName = "test-cilium-cluster";
     string context = "kind-" + clusterName;
+    CiliumProvisioner ciliumProvisioner = new(context: "kind-" + clusterName);
+
     string configPath = Path.Combine(AppContext.BaseDirectory, "assets/kind.yaml");
     var cancellationToken = new CancellationToken();
 
     // Act
     await _kindProvisioner.DeleteAsync(clusterName, cancellationToken);
     await _kindProvisioner.CreateAsync(clusterName, configPath, cancellationToken);
-    await _ciliumProvisioner.InstallAsync(context, cancellationToken);
+    await ciliumProvisioner.InstallAsync(cancellationToken);
 
     // Cleanup
     await _kindProvisioner.DeleteAsync(clusterName, cancellationToken);


### PR DESCRIPTION
Introduce a kubeconfig parameter to the CNIProvisioners and update the InstallAsync method to utilize it, enhancing configuration flexibility.