### PR TITLE
feat: implement ApplySets for kubectl apply with pruning

### DIFF
--- a/src/Devantler.KubernetesProvisioner.Deployment.Core/IDeploymentToolProvisioner.cs
+++ b/src/Devantler.KubernetesProvisioner.Deployment.Core/IDeploymentToolProvisioner.cs
@@ -22,4 +22,9 @@ public interface IDeploymentToolProvisioner
   /// <param name="timeout"></param>
   /// <param name="cancellationToken"></param>
   Task PushAsync(string kustomizationDirectory, string timeout = "5m", CancellationToken cancellationToken = default);
+
+  /// <summary>
+  /// Reconcile resources on the Kubernetes cluster.
+  /// </summary>
+  Task ReconcileAsync(string kustomizationDirectory, string timeout = "5m", CancellationToken cancellationToken = default);
 }

--- a/src/Devantler.KubernetesProvisioner.Deployment.Kubectl/Devantler.KubernetesProvisioner.Deployment.Kubectl.csproj
+++ b/src/Devantler.KubernetesProvisioner.Deployment.Kubectl/Devantler.KubernetesProvisioner.Deployment.Kubectl.csproj
@@ -19,4 +19,8 @@
     <ProjectReference Include="..\Devantler.KubernetesProvisioner.Deployment.Core\Devantler.KubernetesProvisioner.Deployment.Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="assets/k8s/*" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
+  </ItemGroup>
+
 </Project>

--- a/src/Devantler.KubernetesProvisioner.Deployment.Kubectl/assets/k8s/apply-set-cr.yaml
+++ b/src/Devantler.KubernetesProvisioner.Deployment.Kubectl/assets/k8s/apply-set-cr.yaml
@@ -1,0 +1,11 @@
+apiVersion: k8s.devantler.tech/v1
+kind: ApplySet
+metadata:
+  name: ksail
+  annotations:
+    applyset.kubernetes.io/tooling: "kubectl/v1.32.3"
+    applyset.kubernetes.io/contains-group-kinds: "Deployment.apps"
+  labels:
+    applyset.kubernetes.io/id: "applyset-UG-KqWfGc9D8EBUO6vM3DO-AVJmtBLTk95UF_fHcaxM-v1"
+spec:
+  description: "ApplySet parent object for ksail"

--- a/src/Devantler.KubernetesProvisioner.Deployment.Kubectl/assets/k8s/apply-set-crd.yaml
+++ b/src/Devantler.KubernetesProvisioner.Deployment.Kubectl/assets/k8s/apply-set-crd.yaml
@@ -1,0 +1,27 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: applysets.k8s.devantler.tech
+  labels:
+    applyset.kubernetes.io/is-parent-type: "true"
+spec:
+  group: k8s.devantler.tech
+  names:
+    kind: ApplySet
+    listKind: ApplySetList
+    plural: applysets
+    singular: applyset
+  scope: Cluster
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                description:
+                  type: string

--- a/src/Devantler.KubernetesProvisioner.GitOps.Core/IGitOpsProvisioner.cs
+++ b/src/Devantler.KubernetesProvisioner.GitOps.Core/IGitOpsProvisioner.cs
@@ -31,9 +31,4 @@ public interface IGitOpsProvisioner : IDeploymentToolProvisioner
   /// Uninstall the GitOps tooling from the Kubernetes cluster.
   /// </summary>
   Task UninstallAsync(CancellationToken cancellationToken = default);
-
-  /// <summary>
-  /// Reconcile resources on the Kubernetes cluster.
-  /// </summary>
-  Task ReconcileAsync(string timeout = "5m", CancellationToken cancellationToken = default);
 }

--- a/src/Devantler.KubernetesProvisioner.GitOps.Flux/FluxProvisioner.cs
+++ b/src/Devantler.KubernetesProvisioner.GitOps.Flux/FluxProvisioner.cs
@@ -63,7 +63,7 @@ public partial class FluxProvisioner(Uri registryUri, string? registryUserName =
     await CreateKustomizationAsync(kustomizationDirectory, interval: "1m", cancellationToken).ConfigureAwait(false);
   }
   /// <inheritdoc/>
-  public async Task ReconcileAsync(string timeout = "5m", CancellationToken cancellationToken = default)
+  public async Task ReconcileAsync(string kustomizationDirectory, string timeout = "5m", CancellationToken cancellationToken = default)
   {
     using var kubernetesResourceProvisioner = new KubernetesResourceProvisioner(Kubeconfig, Context);
     var kustomizationList = await kubernetesResourceProvisioner.ListNamespacedCustomObjectAsync<FluxKustomizationList>(

--- a/tests/Devantler.KubernetesProvisioner.Deployment.Kubectl.Tests/KubectlProvisionerTests/AllMethodsTests.cs
+++ b/tests/Devantler.KubernetesProvisioner.Deployment.Kubectl.Tests/KubectlProvisionerTests/AllMethodsTests.cs
@@ -34,6 +34,7 @@ public class AllMethodsTests
     await _kindProvisioner.DeleteAsync(clusterName, cancellationToken);
     await _kindProvisioner.CreateAsync(clusterName, configPath, cancellationToken);
     await kubectlProvisioner.PushAsync(kustomizationDirectoryPath, cancellationToken: cancellationToken);
+    await kubectlProvisioner.ReconcileAsync(kustomizationDirectoryPath, cancellationToken: cancellationToken);
 
     // Cleanup
     await _kindProvisioner.DeleteAsync(clusterName, cancellationToken);

--- a/tests/Devantler.KubernetesProvisioner.GitOps.Flux.Tests/FluxProvisionerTests/AllMethodsTests.cs
+++ b/tests/Devantler.KubernetesProvisioner.GitOps.Flux.Tests/FluxProvisionerTests/AllMethodsTests.cs
@@ -48,7 +48,7 @@ public class AllMethodsTests
     }
 
     await fluxProvisioner.InstallAsync(ociUri, kustomizationDirectoryPath, true, cancellationToken: cancellationToken);
-    await fluxProvisioner.ReconcileAsync(cancellationToken: cancellationToken);
+    await fluxProvisioner.ReconcileAsync(manifestsDirectoryPath, cancellationToken: cancellationToken);
     await fluxProvisioner.UninstallAsync(cancellationToken);
 
     // Cleanup


### PR DESCRIPTION
Introduce ApplySets to enhance the kubectl apply command with pruning capabilities. Add a new ReconcileAsync method for reconciling resources on the Kubernetes cluster. Include necessary CustomResourceDefinition and ApplySet configurations.