### PR TITLE
feat: add cloud-provider-kind container to support LoadBalancer type on Services for Kind clusters

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -52,6 +52,7 @@ dotnet_naming_style.constant_style.capitalization = pascal_case
 
 # Disable rules
 dotnet_diagnostic.CA1014.severity = none
+dotnet_diagnostic.CA1303.severity = none
 
 [*.{received,verified}.*]
 generated_code = true

--- a/src/Devantler.KubernetesProvisioner.Cluster.Kind/KindProvisioner.cs
+++ b/src/Devantler.KubernetesProvisioner.Cluster.Kind/KindProvisioner.cs
@@ -29,12 +29,17 @@ public class KindProvisioner : IKubernetesClusterProvisioner
       throw new KubernetesClusterProvisionerException("Failed to delete Kind cluster.");
     }
 
-    Console.WriteLine($"Deleting {clusterName}-cloud-provider-kind container...");
-    _ = await _dockerClient.Containers.StopContainerAsync(
-      $"{clusterName}-cloud-provider-kind",
-      new ContainerStopParameters(),
-      cancellationToken
-    ).ConfigureAwait(false);
+    var containers = await _dockerClient.Containers.ListContainersAsync(new ContainersListParameters { All = true }, cancellationToken).ConfigureAwait(false);
+    var container = containers.FirstOrDefault(c => c.Names.Any(name => name.Equals($"/{clusterName}-cloud-provider-kind", StringComparison.OrdinalIgnoreCase)));
+    if (container != null)
+    {
+      Console.WriteLine($"Deleting {clusterName}-cloud-provider-kind container...");
+      _ = await _dockerClient.Containers.StopContainerAsync(
+        container.ID,
+        new ContainerStopParameters(),
+        cancellationToken
+      ).ConfigureAwait(false);
+    }
   }
 
   /// <inheritdoc />


### PR DESCRIPTION
Introduce cloud-provider-kind functionality to the KindProvisioner, enabling load balancing for Kind clusters. This includes creating and managing a dedicated container for the cloud controller manager.