### PR TITLE
fix: add wait command for CRD applysets in KubectlProvisioner

### DIFF
--- a/src/Devantler.KubernetesProvisioner.Deployment.Kubectl/KubectlProvisioner.cs
+++ b/src/Devantler.KubernetesProvisioner.Deployment.Kubectl/KubectlProvisioner.cs
@@ -56,6 +56,16 @@ public class KubectlProvisioner(string? kubeconfig = default, string? context = 
       _ = await KubectlCLI.Kubectl.RunAsync([.. args], cancellationToken: cancellationToken).ConfigureAwait(false);
       args =
       [
+        "wait",
+        "--for=condition=established",
+        "--timeout=60s",
+        "crd", "applysets.k8s.devantler.tech"
+      ];
+      args.AddIfNotNull("--kubeconfig={0}", Kubeconfig);
+      args.AddIfNotNull("--context={0}", Context);
+      _ = await KubectlCLI.Kubectl.RunAsync([.. args], cancellationToken: cancellationToken).ConfigureAwait(false);
+      args =
+      [
         "apply",
         "-f", Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "assets", "k8s", "apply-set-cr.yaml")
       ];

--- a/tests/Devantler.KubernetesProvisioner.Deployment.Kubectl.Tests/KubectlProvisionerTests/AllMethodsTests.cs
+++ b/tests/Devantler.KubernetesProvisioner.Deployment.Kubectl.Tests/KubectlProvisionerTests/AllMethodsTests.cs
@@ -15,7 +15,7 @@ public class AllMethodsTests
   /// </summary>
   /// <returns></returns>
   [Fact]
-  public async Task Flux_InstallsAndReconciles_KustomizationsAsync()
+  public async Task Kubectl_InstallsAndReconciles_KustomizationsAsync()
   {
     //TODO: Support MacOS and Windows, when dind is supported in GitHub Actions Runners on those platforms
     if ((RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) && Environment.GetEnvironmentVariable("GITHUB_ACTIONS") == "true")


### PR DESCRIPTION
Introduce a wait command to ensure that the Custom Resource Definition (CRD) applysets are established before proceeding with further operations. Update the test method name for clarity.